### PR TITLE
Return 404 when listing versions for non-existing subject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+/vendor
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+### Intellij ###
+.idea
+
+### VisualStudioCode ###
+.vscode

--- a/registry.go
+++ b/registry.go
@@ -221,11 +221,11 @@ func (r *SchemaRegistry) SubjectVersionsByID(ctx context.Context, id int) ([]sr.
 	return sss, nil
 }
 
-func (r *SchemaRegistry) SchemaVersionsBySubject(ctx context.Context, subject string) ([]sr.SubjectSchema, error) {
+func (r *SchemaRegistry) SchemaVersionsBySubject(ctx context.Context, subject string) ([]int, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	sss := make([]sr.SubjectSchema, len(r.subjectVersionCache[subject]))
+	sss := make([]int, len(r.subjectVersionCache[subject]))
 	// TODO this could be optimized to make a single round trip to the store
 	for i, version := range r.subjectVersionCache[subject] {
 		ss, err := r.subjectSchemaStore.Get(ctx, subject, version)
@@ -235,9 +235,12 @@ func (r *SchemaRegistry) SchemaVersionsBySubject(ctx context.Context, subject st
 			}
 			return nil, fmt.Errorf("failed to get subject schema from store: %w", err)
 		}
-		sss[i] = ss
+		sss[i] = ss.Version
 	}
 
+	if len(sss) == 0 {
+		return nil, ErrSubjectNotFound
+	}
 	return sss, nil
 }
 

--- a/registry.go
+++ b/registry.go
@@ -225,23 +225,14 @@ func (r *SchemaRegistry) SchemaVersionsBySubject(ctx context.Context, subject st
 	r.m.Lock()
 	defer r.m.Unlock()
 
-	sss := make([]int, len(r.subjectVersionCache[subject]))
-	// TODO this could be optimized to make a single round trip to the store
-	for i, version := range r.subjectVersionCache[subject] {
-		ss, err := r.subjectSchemaStore.Get(ctx, subject, version)
-		if err != nil {
-			if errors.Is(err, database.ErrKeyNotExist) {
-				return nil, ErrSubjectNotFound
-			}
-			return nil, fmt.Errorf("failed to get subject schema from store: %w", err)
-		}
-		sss[i] = ss.Version
-	}
-
-	if len(sss) == 0 {
+	if len(r.subjectVersionCache[subject]) == 0 {
 		return nil, ErrSubjectNotFound
 	}
-	return sss, nil
+
+	versions := make([]int, len(r.subjectVersionCache[subject]))
+	copy(versions, r.subjectVersionCache[subject])
+
+	return versions, nil
 }
 
 func (r *SchemaRegistry) nextID() int {


### PR DESCRIPTION
### Description

This PR fixes two issues with the endpoint that returns versions for a given subject name:
1. Currently, when listing versions for a non-existing subject, an empty array is returned. Instead, 404(01) needs to be returned.
2. The endpoint fails when returning versions for an existing subject, because it needs to return an array of integers, but it returns an array of SchemaSubject objects.

Reference: https://docs.confluent.io/platform/current/schema-registry/develop/api.html#get--subjects-(string-%20subject)-versions

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-schema-registry/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
