### PR TITLE
Fix ID sequence when restarting the registry

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -141,6 +141,10 @@ func (r *SchemaRegistry) CreateSchema(ctx context.Context, subject string, schem
 	if err != nil {
 		return sr.SubjectSchema{}, err
 	}
+	err = r.idSequenceStore.Set(ctx, r.idSequence)
+	if err != nil {
+		return sr.SubjectSchema{}, err
+	}
 
 	if txn != nil {
 		// commit the transaction if we created it

--- a/registry_test.go
+++ b/registry_test.go
@@ -45,7 +45,7 @@ func TestSchemaRegistry_ID_Sequence(t *testing.T) {
 	is.NoErr(err)
 	is.Equal("", cmp.Diff(wantSchema1, gotSubjectSchema1))
 
-	// Create second SubjectSchema, should get a new ID
+	// Create second SubjectSchema with a new schema, should get a new ID
 	wantSchema2 := sr.SubjectSchema{
 		Subject: "test-subject",
 		Version: 2,
@@ -60,7 +60,7 @@ func TestSchemaRegistry_ID_Sequence(t *testing.T) {
 	underTestRestarted, err := NewSchemaRegistry(db)
 	is.NoErr(err)
 
-	// Create third SubjectSchema, should get a new ID
+	// Create third SubjectSchema with a new schema, should get a new ID
 	wantSchema3 := sr.SubjectSchema{
 		Subject: "test-subject-new",
 		Version: 1,

--- a/registry_test.go
+++ b/registry_test.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	"github.com/conduitio/conduit-commons/database/inmemory"
 	"github.com/google/go-cmp/cmp"
 	"github.com/matryer/is"
 	"github.com/twmb/franz-go/pkg/sr"
-	"testing"
 )
 
 func TestSchemaRegistry_ID_Sequence(t *testing.T) {
@@ -96,12 +97,10 @@ func generateAvroSchema(is *is.I, numFields int) sr.Schema {
 	// Populate fields
 	fields := make([]map[string]interface{}, numFields)
 	for i := 0; i < numFields; i++ {
-		fieldName := fmt.Sprintf("example_field_%d", i+1)
-		field := map[string]interface{}{
-			"name": fieldName,
+		fields[i] = map[string]interface{}{
+			"name": fmt.Sprintf("example_field_%d", i+1),
 			"type": "string",
 		}
-		fields = append(fields, field)
 	}
 
 	// Update schema with fields

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,116 @@
+// Copyright © 2024 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemaregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/google/go-cmp/cmp"
+	"github.com/matryer/is"
+	"github.com/twmb/franz-go/pkg/sr"
+	"testing"
+)
+
+func TestSchemaRegistry_ID_Sequence(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+	db := &inmemory.DB{}
+
+	underTest, err := NewSchemaRegistry(db)
+	is.NoErr(err)
+
+	// Create first SubjectSchema
+	wantSchema1 := sr.SubjectSchema{
+		Subject: "test-subject",
+		Version: 1,
+		ID:      1,
+		Schema:  generateAvroSchema(is, 1),
+	}
+	gotSubjectSchema1, err := underTest.CreateSchema(ctx, wantSchema1.Subject, wantSchema1.Schema)
+	is.NoErr(err)
+	is.Equal("", cmp.Diff(wantSchema1, gotSubjectSchema1))
+
+	// Create second SubjectSchema, should get a new ID
+	wantSchema2 := sr.SubjectSchema{
+		Subject: "test-subject",
+		Version: 2,
+		ID:      2,
+		Schema:  generateAvroSchema(is, 2),
+	}
+	gotSubjectSchema2, err := underTest.CreateSchema(ctx, wantSchema2.Subject, wantSchema2.Schema)
+	is.NoErr(err)
+	is.Equal("", cmp.Diff(wantSchema2, gotSubjectSchema2))
+
+	// Simulate a restart
+	underTestRestarted, err := NewSchemaRegistry(db)
+	is.NoErr(err)
+
+	// Create third SubjectSchema, should get a new ID
+	wantSchema3 := sr.SubjectSchema{
+		Subject: "test-subject-new",
+		Version: 1,
+		ID:      3,
+		Schema:  generateAvroSchema(is, 3),
+	}
+	gotSubjectSchema3, err := underTestRestarted.CreateSchema(ctx, wantSchema3.Subject, wantSchema3.Schema)
+	is.NoErr(err)
+	is.Equal("", cmp.Diff(wantSchema3, gotSubjectSchema3))
+
+	// Create fourth SubjectSchema, that has the schema as in wantSchema2
+	// The registry should use the existing schema's ID
+	wantSchema4 := sr.SubjectSchema{
+		Subject: "test-subject-new",
+		Version: 2,
+		ID:      2,
+		Schema:  generateAvroSchema(is, 2),
+	}
+	gotSubjectSchema4, err := underTestRestarted.CreateSchema(ctx, wantSchema4.Subject, wantSchema4.Schema)
+	is.NoErr(err)
+	is.Equal("", cmp.Diff(wantSchema4, gotSubjectSchema4))
+}
+
+// generateAvroSchema generates an Avro schema with a given number of string fields
+func generateAvroSchema(is *is.I, numFields int) sr.Schema {
+	is.Helper()
+
+	// Create a map for the schema
+	schema := map[string]interface{}{
+		"type": "record",
+		"name": "ExampleRecord",
+	}
+
+	// Populate fields
+	fields := make([]map[string]interface{}, numFields)
+	for i := 0; i < numFields; i++ {
+		fieldName := fmt.Sprintf("example_field_%d", i+1)
+		field := map[string]interface{}{
+			"name": fieldName,
+			"type": "string",
+		}
+		fields = append(fields, field)
+	}
+
+	// Update schema with fields
+	schema["fields"] = fields
+	bytes, err := json.Marshal(schema)
+	is.NoErr(err)
+
+	return sr.Schema{
+		Schema: string(bytes),
+		Type:   sr.TypeAvro,
+	}
+}


### PR DESCRIPTION
### Description

Fixes https://github.com/ConduitIO/conduit/issues/1941.

The registry wasn't saving the ID sequence to the DB. The implication was that, when it was restarted, the ID sequence started again from 0, which means that newly created schema got IDs of existing schemas.

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-schema-registry/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
