### PR TITLE
Add cache + goccy/go-json

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -119,13 +119,13 @@ linters:
     - sqlclosecheck
     - staticcheck
     - stylecheck
-    - tenv
     - testableexamples
     # - thelper
     - unconvert
     # - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
     - wrapcheck

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/matryer/is v1.4.1
 	github.com/neilotoole/slogt v1.1.0
 	github.com/twmb/franz-go/pkg/sr v1.3.0
+	github.com/twmb/go-cache v1.2.1
+	go.uber.org/mock v0.5.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.2
 
 require (
 	github.com/conduitio/conduit-commons v0.5.2
+	github.com/goccy/go-json v0.10.5
 	github.com/golangci/golangci-lint v1.64.8
 	github.com/google/go-cmp v0.7.0
 	github.com/matryer/is v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,8 @@ github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/twmb/franz-go/pkg/sr v1.3.0 h1:UlXpZ2suGgylzQBUb6Wn1jzqVShoPGzt7BbixznJ4qo=
 github.com/twmb/franz-go/pkg/sr v1.3.0/go.mod h1:gpd2Xl5/prkj3gyugcL+rVzagjaxFqMgvKMYcUlrpDw=
+github.com/twmb/go-cache v1.2.1 h1:yUkLutow4S2x5NMbqFW24o14OsucoFI5Fzmlb6uBinM=
+github.com/twmb/go-cache v1.2.1/go.mod h1:lArg9KhCl+GTFMikitLGhIBh/i11OK0lhSveqlMbbrY=
 github.com/ultraware/funlen v0.2.0 h1:gCHmCn+d2/1SemTdYMiKLAHFYxTYz7z9VIDRaTGyLkI=
 github.com/ultraware/funlen v0.2.0/go.mod h1:ZE0q4TsJ8T1SQcjmkhN/w+MceuatI6pBFSxxyteHIJA=
 github.com/ultraware/whitespace v0.2.0 h1:TYowo2m9Nfj1baEQBjuHzvMRbp19i+RCcRYrSWoFa+g=
@@ -434,6 +436,8 @@ go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
+go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUW
 github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 h1:WUvBfQL6EW/40l6OmeSBYQJNSif4O11+bmWEz+C7FYw=

--- a/registry_test.go
+++ b/registry_test.go
@@ -16,11 +16,11 @@ package schemaregistry
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/conduitio/conduit-commons/database/inmemory"
+	"github.com/goccy/go-json"
 	"github.com/google/go-cmp/cmp"
 	"github.com/matryer/is"
 	"github.com/twmb/franz-go/pkg/sr"

--- a/server.go
+++ b/server.go
@@ -15,12 +15,12 @@
 package schemaregistry
 
 import (
-	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
 
+	"github.com/goccy/go-json"
 	"github.com/twmb/franz-go/pkg/sr"
 )
 

--- a/store.go
+++ b/store.go
@@ -71,9 +71,13 @@ func (s *schemaStore) Get(ctx context.Context, id int) (sr.Schema, error) {
 		if err != nil {
 			return sr.Schema{}, fmt.Errorf("failed to get schema with ID %q: %w", id, err)
 		}
-		return s.decode(raw)
+		sch, err := s.decode(raw)
+		if err != nil {
+			return sr.Schema{}, fmt.Errorf("failed to decode schema with ID %q: %w", id, err)
+		}
+		return sch, nil
 	})
-	return sch, err
+	return sch, err //nolint:wrapcheck // Error is wrapped in the function above
 }
 
 func (s *schemaStore) Delete(ctx context.Context, id int) error {
@@ -81,7 +85,7 @@ func (s *schemaStore) Delete(ctx context.Context, id int) error {
 	if err != nil {
 		return fmt.Errorf("failed to delete schema with ID %q: %w", id, err)
 	}
-	_, _, _ = s.cache.Delete(id)
+	s.cache.Delete(id) //nolint:errcheck // We don't care if the key doesn't exist
 
 	return nil
 }
@@ -93,14 +97,14 @@ func (*schemaStore) toKey(id int) string {
 
 // encode from sr.Schema to []byte.
 func (*schemaStore) encode(s sr.Schema) ([]byte, error) {
-	return json.Marshal(s)
+	return json.Marshal(s) //nolint:wrapcheck // We don't care about wrapping here
 }
 
 // decode from []byte to sr.Schema.
 func (s *schemaStore) decode(raw []byte) (sr.Schema, error) {
 	var out sr.Schema
 	err := json.Unmarshal(raw, &out)
-	return out, err
+	return out, err //nolint:wrapcheck // We don't care about wrapping here
 }
 
 const (
@@ -159,7 +163,7 @@ func (s *subjectSchemaStore) getByKey(ctx context.Context, key string) (sr.Subje
 		}
 		return ss, nil
 	})
-	return ss, err
+	return ss, err //nolint:wrapcheck // Error is wrapped in the function above
 }
 
 func (s *subjectSchemaStore) GetAll(ctx context.Context) ([]sr.SubjectSchema, error) {
@@ -191,7 +195,7 @@ func (s *subjectSchemaStore) Delete(ctx context.Context, subject string, version
 		return fmt.Errorf("failed to delete subject schema with subject:version %q: %w", key, err)
 	}
 
-	_, _, _ = s.cache.Delete(key)
+	s.cache.Delete(key) //nolint:errcheck // We don't care if the key doesn't exist
 
 	return nil
 }
@@ -203,14 +207,14 @@ func (*subjectSchemaStore) toKey(subject string, version int) string {
 
 // encode from sr.SubjectSchema to []byte.
 func (*subjectSchemaStore) encode(ss sr.SubjectSchema) ([]byte, error) {
-	return json.Marshal(ss)
+	return json.Marshal(ss) //nolint:wrapcheck // We don't care about wrapping here
 }
 
 // decode from []byte to sr.SubjectSchema.
 func (s *subjectSchemaStore) decode(raw []byte) (sr.SubjectSchema, error) {
 	var out sr.SubjectSchema
 	err := json.Unmarshal(raw, &out)
-	return out, err
+	return out, err //nolint:wrapcheck // We don't care about wrapping here
 }
 
 const (

--- a/store.go
+++ b/store.go
@@ -16,13 +16,13 @@ package schemaregistry
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/conduitio/conduit-commons/database"
+	"github.com/goccy/go-json"
 	"github.com/twmb/franz-go/pkg/sr"
 	"github.com/twmb/go-cache/cache"
 )

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,159 @@
+// Copyright © 2025 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schemaregistry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/conduitio/conduit-commons/database"
+	"github.com/conduitio/conduit-commons/database/mock"
+	"github.com/matryer/is"
+	"github.com/twmb/franz-go/pkg/sr"
+	"go.uber.org/mock/gomock"
+)
+
+func TestSchemaStore_Cache(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	db := mock.NewDB(ctrl)
+	store := newSchemaStore(db)
+
+	schema := sr.Schema{
+		Schema:     `{"name":"foo", "type": "record", "fields":[{"name":"str", "type": "string"}]}`,
+		Type:       sr.TypeAvro,
+		References: nil,
+		SchemaMetadata: &sr.SchemaMetadata{
+			Tags:       map[string][]string{"foo": {"bar"}},
+			Properties: map[string]string{"bar": "baz"},
+			Sensitive:  []string{"baz"},
+		},
+		SchemaRuleSet: nil,
+	}
+	schemaJson, _ := json.Marshal(schema)
+
+	// First simulate a cache miss and a db miss
+	t.Run("cache miss and db miss", func(t *testing.T) {
+		db.EXPECT().Get(ctx, "schemaregistry:schema:1").Return(nil, database.ErrKeyNotExist)
+		_, err := store.Get(ctx, 1)
+		is.True(errors.Is(err, database.ErrKeyNotExist))
+	})
+
+	// Non-existent schema should be cached now
+	t.Run("cache hit, key not found", func(t *testing.T) {
+		_, err := store.Get(ctx, 1)
+		is.True(errors.Is(err, database.ErrKeyNotExist))
+	})
+
+	// Now simulate a set
+	t.Run("set", func(t *testing.T) {
+		db.EXPECT().Set(ctx, "schemaregistry:schema:1", schemaJson).Return(nil)
+		err := store.Set(ctx, 1, schema)
+		is.NoErr(err)
+	})
+
+	// Next time we should get a cache hit
+	t.Run("cache hit, key found", func(t *testing.T) {
+		got, err := store.Get(ctx, 1)
+		is.NoErr(err)
+		is.Equal(schema, got)
+	})
+
+	// Now delete the schema
+	t.Run("delete", func(t *testing.T) {
+		db.EXPECT().Set(ctx, "schemaregistry:schema:1", nil).Return(nil)
+		err := store.Delete(ctx, 1)
+		is.NoErr(err)
+	})
+
+	// Again, we should be at an empty cache state and a db miss
+	t.Run("cache miss and db miss 2", func(t *testing.T) {
+		db.EXPECT().Get(ctx, "schemaregistry:schema:1").Return(nil, database.ErrKeyNotExist)
+		_, err := store.Get(ctx, 1)
+		is.True(errors.Is(err, database.ErrKeyNotExist))
+	})
+}
+
+func TestSubjectSchemaStore_Cache(t *testing.T) {
+	is := is.New(t)
+	ctx := context.Background()
+
+	ctrl := gomock.NewController(t)
+	db := mock.NewDB(ctrl)
+	store := newSubjectSchemaStore(db)
+
+	subjectSchema := sr.SubjectSchema{
+		Subject: "foo",
+		Version: 1,
+		ID:      2,
+		Schema: sr.Schema{
+			Schema:     `{"name":"foo", "type": "record", "fields":[{"name":"str", "type": "string"}]}`,
+			Type:       sr.TypeAvro,
+			References: nil,
+			SchemaMetadata: &sr.SchemaMetadata{
+				Tags:       map[string][]string{"foo": {"bar"}},
+				Properties: map[string]string{"bar": "baz"},
+				Sensitive:  []string{"baz"},
+			},
+			SchemaRuleSet: nil,
+		},
+	}
+	subjectSchemaJson, _ := json.Marshal(subjectSchema)
+
+	// First simulate a cache miss and a db miss
+	t.Run("cache miss and db miss", func(t *testing.T) {
+		db.EXPECT().Get(ctx, "schemaregistry:subjectschema:foo:1").Return(nil, database.ErrKeyNotExist)
+		_, err := store.Get(ctx, "foo", 1)
+		is.True(errors.Is(err, database.ErrKeyNotExist))
+	})
+
+	// Non-existent schema should be cached now
+	t.Run("cache hit, key not found", func(t *testing.T) {
+		_, err := store.Get(ctx, "foo", 1)
+		is.True(errors.Is(err, database.ErrKeyNotExist))
+	})
+
+	// Now simulate a set
+	t.Run("set", func(t *testing.T) {
+		db.EXPECT().Set(ctx, "schemaregistry:subjectschema:foo:1", subjectSchemaJson).Return(nil)
+		err := store.Set(ctx, "foo", 1, subjectSchema)
+		is.NoErr(err)
+	})
+
+	// Next time we should get a cache hit
+	t.Run("cache hit, key found", func(t *testing.T) {
+		got, err := store.Get(ctx, "foo", 1)
+		is.NoErr(err)
+		is.Equal(subjectSchema, got)
+	})
+
+	// Now delete the schema
+	t.Run("delete", func(t *testing.T) {
+		db.EXPECT().Set(ctx, "schemaregistry:subjectschema:foo:1", nil).Return(nil)
+		err := store.Delete(ctx, "foo", 1)
+		is.NoErr(err)
+	})
+
+	// Again, we should be at an empty cache state and a db miss
+	t.Run("cache miss and db miss 2", func(t *testing.T) {
+		db.EXPECT().Get(ctx, "schemaregistry:subjectschema:foo:1").Return(nil, database.ErrKeyNotExist)
+		_, err := store.Get(ctx, "foo", 1)
+		is.True(errors.Is(err, database.ErrKeyNotExist))
+	})
+}

--- a/store_test.go
+++ b/store_test.go
@@ -28,9 +28,7 @@ import (
 )
 
 func TestSchemaStore_Cache(t *testing.T) {
-	is := is.New(t)
 	ctx := context.Background()
-
 	ctrl := gomock.NewController(t)
 	db := mock.NewDB(ctrl)
 	store := newSchemaStore(db)
@@ -46,10 +44,11 @@ func TestSchemaStore_Cache(t *testing.T) {
 		},
 		SchemaRuleSet: nil,
 	}
-	schemaJson, _ := json.Marshal(schema)
+	schemaJSON, _ := json.Marshal(schema)
 
 	// First simulate a cache miss and a db miss
 	t.Run("cache miss and db miss", func(t *testing.T) {
+		is := is.New(t)
 		db.EXPECT().Get(ctx, "schemaregistry:schema:1").Return(nil, database.ErrKeyNotExist)
 		_, err := store.Get(ctx, 1)
 		is.True(errors.Is(err, database.ErrKeyNotExist))
@@ -57,19 +56,22 @@ func TestSchemaStore_Cache(t *testing.T) {
 
 	// Non-existent schema should be cached now
 	t.Run("cache hit, key not found", func(t *testing.T) {
+		is := is.New(t)
 		_, err := store.Get(ctx, 1)
 		is.True(errors.Is(err, database.ErrKeyNotExist))
 	})
 
 	// Now simulate a set
 	t.Run("set", func(t *testing.T) {
-		db.EXPECT().Set(ctx, "schemaregistry:schema:1", schemaJson).Return(nil)
+		is := is.New(t)
+		db.EXPECT().Set(ctx, "schemaregistry:schema:1", schemaJSON).Return(nil)
 		err := store.Set(ctx, 1, schema)
 		is.NoErr(err)
 	})
 
 	// Next time we should get a cache hit
 	t.Run("cache hit, key found", func(t *testing.T) {
+		is := is.New(t)
 		got, err := store.Get(ctx, 1)
 		is.NoErr(err)
 		is.Equal(schema, got)
@@ -77,6 +79,7 @@ func TestSchemaStore_Cache(t *testing.T) {
 
 	// Now delete the schema
 	t.Run("delete", func(t *testing.T) {
+		is := is.New(t)
 		db.EXPECT().Set(ctx, "schemaregistry:schema:1", nil).Return(nil)
 		err := store.Delete(ctx, 1)
 		is.NoErr(err)
@@ -84,6 +87,7 @@ func TestSchemaStore_Cache(t *testing.T) {
 
 	// Again, we should be at an empty cache state and a db miss
 	t.Run("cache miss and db miss 2", func(t *testing.T) {
+		is := is.New(t)
 		db.EXPECT().Get(ctx, "schemaregistry:schema:1").Return(nil, database.ErrKeyNotExist)
 		_, err := store.Get(ctx, 1)
 		is.True(errors.Is(err, database.ErrKeyNotExist))
@@ -91,9 +95,7 @@ func TestSchemaStore_Cache(t *testing.T) {
 }
 
 func TestSubjectSchemaStore_Cache(t *testing.T) {
-	is := is.New(t)
 	ctx := context.Background()
-
 	ctrl := gomock.NewController(t)
 	db := mock.NewDB(ctrl)
 	store := newSubjectSchemaStore(db)
@@ -114,10 +116,11 @@ func TestSubjectSchemaStore_Cache(t *testing.T) {
 			SchemaRuleSet: nil,
 		},
 	}
-	subjectSchemaJson, _ := json.Marshal(subjectSchema)
+	subjectSchemaJSON, _ := json.Marshal(subjectSchema)
 
 	// First simulate a cache miss and a db miss
 	t.Run("cache miss and db miss", func(t *testing.T) {
+		is := is.New(t)
 		db.EXPECT().Get(ctx, "schemaregistry:subjectschema:foo:1").Return(nil, database.ErrKeyNotExist)
 		_, err := store.Get(ctx, "foo", 1)
 		is.True(errors.Is(err, database.ErrKeyNotExist))
@@ -125,19 +128,22 @@ func TestSubjectSchemaStore_Cache(t *testing.T) {
 
 	// Non-existent schema should be cached now
 	t.Run("cache hit, key not found", func(t *testing.T) {
+		is := is.New(t)
 		_, err := store.Get(ctx, "foo", 1)
 		is.True(errors.Is(err, database.ErrKeyNotExist))
 	})
 
 	// Now simulate a set
 	t.Run("set", func(t *testing.T) {
-		db.EXPECT().Set(ctx, "schemaregistry:subjectschema:foo:1", subjectSchemaJson).Return(nil)
+		is := is.New(t)
+		db.EXPECT().Set(ctx, "schemaregistry:subjectschema:foo:1", subjectSchemaJSON).Return(nil)
 		err := store.Set(ctx, "foo", 1, subjectSchema)
 		is.NoErr(err)
 	})
 
 	// Next time we should get a cache hit
 	t.Run("cache hit, key found", func(t *testing.T) {
+		is := is.New(t)
 		got, err := store.Get(ctx, "foo", 1)
 		is.NoErr(err)
 		is.Equal(subjectSchema, got)
@@ -145,6 +151,7 @@ func TestSubjectSchemaStore_Cache(t *testing.T) {
 
 	// Now delete the schema
 	t.Run("delete", func(t *testing.T) {
+		is := is.New(t)
 		db.EXPECT().Set(ctx, "schemaregistry:subjectschema:foo:1", nil).Return(nil)
 		err := store.Delete(ctx, "foo", 1)
 		is.NoErr(err)
@@ -152,6 +159,7 @@ func TestSubjectSchemaStore_Cache(t *testing.T) {
 
 	// Again, we should be at an empty cache state and a db miss
 	t.Run("cache miss and db miss 2", func(t *testing.T) {
+		is := is.New(t)
 		db.EXPECT().Get(ctx, "schemaregistry:subjectschema:foo:1").Return(nil, database.ErrKeyNotExist)
 		_, err := store.Get(ctx, "foo", 1)
 		is.True(errors.Is(err, database.ErrKeyNotExist))

--- a/store_test.go
+++ b/store_test.go
@@ -16,12 +16,12 @@ package schemaregistry
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"testing"
 
 	"github.com/conduitio/conduit-commons/database"
 	"github.com/conduitio/conduit-commons/database/mock"
+	"github.com/goccy/go-json"
 	"github.com/matryer/is"
 	"github.com/twmb/franz-go/pkg/sr"
 	"go.uber.org/mock/gomock"


### PR DESCRIPTION
### Description

This PR introduces a cache in `schemaStore` and `subjectSchemaStore` (separate caches). Additionally, the PR switches the JSON library to [github.com/goccy/go-json](https://github.com/goccy/go-json).

See https://github.com/ConduitIO/conduit-schema-registry/pull/33 for more info.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-schema-registry/pulls) for the same update/change.
- [X] I have written unit tests.
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
